### PR TITLE
다이얼로그 레이아웃이 일부분 안보이는 오류 수정

### DIFF
--- a/app/src/main/java/com/example/contactapp/presentation/AddContact.kt
+++ b/app/src/main/java/com/example/contactapp/presentation/AddContact.kt
@@ -49,7 +49,7 @@ class AddContact(private val position: Int) : DialogFragment() {
 
     override fun onResume() {
         super.onResume()
-        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, 1800) //다이얼로그 크기 조정
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT) //다이얼로그 크기 조정
     }
 
 

--- a/app/src/main/res/layout/custom_dialog.xml
+++ b/app/src/main/res/layout/custom_dialog.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:paddingBottom="40dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
높이값이 px이라 높이가 짧은 에뮬레이터에서는 보이지만 긴 에뮬레이터에서는 아래부분이 안보임 -> 높이를 wrap으로, 레이아웃에서 하단 패딩을 주는것으로 해결